### PR TITLE
FEAT: Add instructions for OCP user access

### DIFF
--- a/roks-cpd-wa-wd-guide/docs/user-access-cpd-instances.md
+++ b/roks-cpd-wa-wd-guide/docs/user-access-cpd-instances.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 8
+---
+
+
+# User Access Part 2 - Adding CPD users from OpenShift
+
+A general overview of user management is included in the [Cloud Pak for Data Documentation](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=a-managing-users-1). For the most simple case of using the OpenShift platform as the identity provider and setting up access to cluster instances the procedure to grant users access to service instances is as follows:
+
+## Creating a user group that will be granted access permissions to the service instance
+
+   1. As the `cpadmin` (or another Administrator role user) select **Access control** in the left menu under the **Administration** group.
+   1. Select the **User groups** tab and then select **New user group**
+   1. Assign a meaningful name for the group, for example "WAWD_Users" and provide a description if desired. Keep the membership type as the default of **Assigned** and click on **Next**
+   1. Click on **Next** to skip assigning users at this time to the group.
+   1. Select the **User** role checkbox and click on **Next**
+   1. Click on **Create** to create the user group.
+
+The following two steps can be repeated multiple times as new users are needed to be added to the service instances.
+
+## Add OpenShift users to the newly created group
+
+   1. Select the newly created user group by clicking on the name of the group.
+   1. Click on **Add users**
+   1. Click on the **Identity provider users** tab
+   1. In the search field, start typing the name of the user from OpenShift (for IBM Cloud and ROKS, this is the user's email address)
+   1. Select the users that are shown. If the user is not shown, ensure they have completed the OpenShift console access step from part 1.
+   1. Search for additional users if necessary. When done click on the **Add user(s)** button
+
+## Provide access to the watsonx Assistant and/or Watson Discovery instances to members in the group
+
+   1. From the left navigation pull-down menu, select **Instances**
+   1. For watsonx Assistant select the right-hand three dot menu of the assistant instance and choose **Manage access**
+   1. Click on **Add users**
+   1. To simplify the list that is displayed, choose to filter by **All user groups**
+   1. Select the checkbox next to the group that was added in the first step
+   1. Select a role of either **User** or **Admin** the capabilities of each role are [described in the documentation](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=a-giving-users-access). In most cases **User** will be sufficient for group members and is the default.
+   1. Click on the **Add user(s)** button
+   1. These same steps may be repeated for Watson Discovery. The different capabilities for **User** and **Admin** role are [described in the documentation](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=administering-giving-users-access)
+
+Once the users have been added - provide them the CPD URL and at Log in page, advise for them to select **OpenShift authentication** as the login method. They may be asked to authenticate to IBM Cloud in this step if their login has expired. This is expected. Once authenticated by OpenShift, the user will be asked to Authorize access to `user:info` for the CPD callback. They should select **Allow selected permissions**, this will complete their login to Cloud Pak for Data with access to watsonx Assistant and Watson Discovery instances.

--- a/roks-cpd-wa-wd-guide/docs/user-access-roks-iam.md
+++ b/roks-cpd-wa-wd-guide/docs/user-access-roks-iam.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 7
+---
+
+
+# User Access Part 1 - IBM Cloud IAM and ROKS
+
+Adding users beyond the `cpadmin` user to Cloud Pak for Data requires configuration of the users in an external Identity Provider. Many Identity Providers are supported, but for a quick start, you can set up additional OpenShift users using IBM Cloud IAM access and then use the initially configured CPD => OpenShift oauth provider to add users to Cloud Pak for Data.
+
+If you are using a different Identity Provider and just want to see how to add those users to a group and watsonx Assistant or Watson Discovery instances, skip ahead to [**User Access Part 2 - Adding CPD users from OpenShift**](./user-access-cpd-instances.md).
+
+## Create an IBM Cloud Access Group allowing access to the OpenShift Cluster
+
+This group will only be needed for IBM Cloud users in the account that do not already have access to the OpenShift Cluster as a developer or administrator
+
+   1. From the IBM Cloud console top menu, select **Manage** -> **Access(IAM)**
+   1. Click on **Create Access Group**
+   1. Give the group a descriptive name like "CPD-VIEWER-OPENSHIFT", optionally, provide more details in the description
+   1. Select the **Access** tab and then click on **Assign access**
+   1. For the Service name, type in **Kubernetes Service** and click on **Next**
+   1. Under Resources, select **Specific resources**, then the **Cluster** attribute type and select your cluster name as the value. Then click on **Add a condition** and select the **Namespace** attribute and type in **default** as the value. Finally, click on **Next**
+   1. Under Roles and actions, for Service access, select **Reader**, and for Platform access, select **Viewer**, then click on **Add**
+   1. On the right side click on **Assign** to grant the policy to the Access Group.
+
+## Add users to the Access Group
+
+   1. If the users are already in the IBM Cloud account, from the Access Group page, select **Users** and then use **Add Users** to add more account users to the access group
+   1. Invite new users to the account by selecting the **Users** item from the left menu and then **Invite users**, provide a list of e-mail addresses of users to invite. Select the Access Group that was added and click on **Add** to include access to the group to the invited users. Then click on **Invite**
+
+New users that are added to the IBM Cloud platform will receive an email, they must click on the account invitation link and join the account before attempting to access the OpenShift cluster. Whether the user was a previous user in the account or was just invited, all users must do an initial sign-in to the OpenShift console in order for their identity to be added to OpenShift. Each user needs to perform this step:
+
+## User accesses the OpenShift cluster from the IBM Cloud Console to create their identity in the OpenShift user registry
+
+   1. From the IBM Cloud Console, open [OpenShift Resources](https://cloud.ibm.com/kubernetes/clusters?platformType=openshift)
+   1. Select the OpenShift cluster (if more than one is shown, select the cluster with Cloud Pak for Data/watsonx Assistant installed)
+   1. From the cluster control panel click on the **OpenShift web console** button to access the OpenShift dashboard.
+   1. Once the dashboard opens, the user can close the tab.
+
+At this point, an OpenShift adminstrator will see the user identity using the Administrator dashboard under **User Management** -> **Users** . Users will be listed like `IAM#userid@example.com`. Once the users are shown, proceed to the next step.

--- a/roks-cpd-wa-wd-guide/sidebars.js
+++ b/roks-cpd-wa-wd-guide/sidebars.js
@@ -25,6 +25,8 @@ const sidebars = {
     "install-watsonx-Assistant",
     "install-Watson-Discovery",
     "login-to-cpd",
+    "user-access-roks-iam",
+    "user-access-cpd-instances"
   ],
 };
 


### PR DESCRIPTION
Tested with OCP 4.8.2 menus and dialog panel names. Should be identical to 4.8.0 and flow will be the same.